### PR TITLE
custom u8string formatter for fmt library

### DIFF
--- a/src/common/logging/formatter.h
+++ b/src/common/logging/formatter.h
@@ -19,3 +19,27 @@ struct fmt::formatter<T, std::enable_if_t<std::is_enum_v<T>, char>>
     }
 };
 #endif
+
+namespace fmt {
+template <typename T = std::string_view>
+struct UTF {
+    T data;
+
+    explicit UTF(const std::u8string_view view) {
+        data = T{(const char*)&view.front(), (const char*)&view.back()};
+    }
+
+    explicit UTF(const std::u8string& str)
+        : UTF(std::u8string_view{str}) {
+    }
+};
+}
+
+template <>
+struct fmt::formatter<fmt::UTF<std::string_view>, char>
+    : formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const UTF<std::string_view>& wrapper, FormatContext& ctx) const {
+        return formatter<std::string_view>::format(wrapper.data, ctx);
+    }
+};


### PR DESCRIPTION
This will allow you to use u8string in fmt.

Example:
```diff
diff --git a/src/common/config.cpp b/src/common/config.cpp
index fb4acac1..4ff6d3ea 100644
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <string>
 #include <fmt/core.h>
+#include <common/logging/formatter.h>
 #include <fmt/xchar.h> // for wstring support
 #include <toml.hpp>
 #include "config.h"
@@ -445,18 +446,12 @@ void save(const std::filesystem::path& path) {
             return;
         }
     } else {
-#ifdef _WIN32
-#define PREFIX(str) L##str
-#else
-#define PREFIX(str) str
-#endif
         if (error) {
-            fmt::print(PREFIX("Filesystem error accessing {}"), path.native());
+            fmt::print("Filesystem error accessing {}", fmt::UTF(path.u8string()));
             // can't mix wstring and string in fmt
             fmt::print(" (error: {})\n", error.message());
         }
-        fmt::print(PREFIX("Saving new configuration file {}\n"), path.native());
-#undef PREFIX
+        fmt::print("Saving new configuration file {}\n", fmt::UTF(path.u8string()));
     }
 
     data["General"]["isPS4Pro"] = isNeo;
```


It will output the raw UTF-8 bytes. For Windows, I recommend adding `SetConsoleOutputCP(CP_UTF8);` at the beginning of the main func to allow cmd to interpret it correctly